### PR TITLE
Updated Send Class Reminder Tests, and added new tests for the Set Notification Preferences Endpoint

### DIFF
--- a/app/db/classes.py
+++ b/app/db/classes.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from app.db.utils import serialize_item, serialize_items, serialize_class
+from app.db.utils import serialize_class
 from app.db import DB
 from bson import ObjectId
 
@@ -66,6 +66,8 @@ class ClassResource:
             return None
 
         class_doc = self.collection.find_one({"_id": oid})
+        if class_doc is None:
+            return None
         return serialize_class(class_doc)
 
     def add_user_to_class(self, class_id: str, user_id: str)->str:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from flask_jwt_extended import create_access_token
 from app import create_app
 from app.db import DB
+import os
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -24,7 +25,7 @@ def runner(app):
 
 @pytest.fixture
 def trainer_token(app):
-    with app.app_context()
+    with app.app_context():
         return create_access_token(
                 identity="testId",
                 additional_claims={"role": "trainer"},

--- a/tests/unit/test_notification_prefs.py
+++ b/tests/unit/test_notification_prefs.py
@@ -1,0 +1,145 @@
+from http import HTTPStatus
+import pytest
+from flask_jwt_extended import create_access_token
+from app.apis import MSG
+from app.db.users import USER_NOTIFICATION_PREFS, USER_TELEGRAM_CHAT_ID
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_prefs_no_auth(client):
+    resp = client.put("/users/me/notifications", json={"notification_prefs": {"email": True}})
+    assert resp.status_code != HTTPStatus.OK
+
+
+def test_prefs_wrong_role_forbidden(client, app):
+    with app.app_context():
+        guest_token = create_access_token(
+            identity="testId", additional_claims={"role": "guest"}
+        )
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"email": True}},
+        headers=_auth(guest_token),
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_prefs_missing_prefs_key(client, member_token):
+    resp = client.put("/users/me/notifications", json={}, headers=_auth(member_token))
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "email" in resp.json[MSG] and "telegram" in resp.json[MSG]
+
+
+def test_prefs_empty_prefs(client, member_token):
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {}},
+        headers=_auth(member_token),
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_prefs_unknown_channels_only(client, member_token):
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"sms": True}},
+        headers=_auth(member_token),
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_prefs_email_only(client, member_token, mocker):
+    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
+    mock_resource.update_notification_prefs.return_value = (True, "")
+
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"email": True}},
+        headers=_auth(member_token),
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    mock_resource.update_notification_prefs.assert_called_once_with(
+        "testId", {USER_NOTIFICATION_PREFS: {"email": True}}
+    )
+
+
+def test_prefs_telegram_no_chat_id(client, member_token):
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"telegram": True}},
+        headers=_auth(member_token),
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "telegram_chat_id" in resp.json[MSG]
+
+
+def test_prefs_telegram_empty_chat_id(client, member_token):
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"telegram": True}, "telegram_chat_id": "   "},
+        headers=_auth(member_token),
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "telegram_chat_id" in resp.json[MSG]
+
+
+def test_prefs_telegram_with_chat_id(client, member_token, mocker):
+    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
+    mock_resource.update_notification_prefs.return_value = (True, "")
+
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"telegram": True}, "telegram_chat_id": "12345"},
+        headers=_auth(member_token),
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    mock_resource.update_notification_prefs.assert_called_once_with(
+        "testId",
+        {USER_NOTIFICATION_PREFS: {"telegram": True}, USER_TELEGRAM_CHAT_ID: "12345"},
+    )
+
+
+def test_prefs_telegram_disabled_no_chat_id_needed(client, member_token, mocker):
+    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
+    mock_resource.update_notification_prefs.return_value = (True, "")
+
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"telegram": False}},
+        headers=_auth(member_token),
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    called_args = mock_resource.update_notification_prefs.call_args[0]
+    assert USER_TELEGRAM_CHAT_ID not in called_args[1]
+
+
+def test_prefs_user_not_found(client, member_token, mocker):
+    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
+    mock_resource.update_notification_prefs.return_value = (False, "User not found")
+
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"email": True}},
+        headers=_auth(member_token),
+    )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_prefs_db_error(client, member_token, mocker):
+    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
+    mock_resource.update_notification_prefs.return_value = (False, "Invalid user ID")
+
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"email": True}},
+        headers=_auth(member_token),
+    )
+
+    assert resp.status_code == HTTPStatus.BAD_REQUEST

--- a/tests/unit/test_notification_prefs.py
+++ b/tests/unit/test_notification_prefs.py
@@ -1,12 +1,28 @@
 from http import HTTPStatus
 import pytest
+from bson import ObjectId
 from flask_jwt_extended import create_access_token
 from app.apis import MSG
-from app.db.users import USER_NOTIFICATION_PREFS, USER_TELEGRAM_CHAT_ID
+from app.db.users import UserResource, USER_NOTIFICATION_PREFS, USER_TELEGRAM_CHAT_ID
 
 
 def _auth(token):
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def member_with_token(app):
+    user_resource = UserResource()
+    uid = user_resource.create_user("Test Member", "testmember@example.com", "member")
+
+    with app.app_context():
+        token = create_access_token(
+            identity=str(uid), additional_claims={"role": "member"}
+        )
+
+    yield token, str(uid)
+
+    user_resource.collection.delete_one({"_id": uid})
 
 
 def test_prefs_no_auth(client):
@@ -51,22 +67,6 @@ def test_prefs_unknown_channels_only(client, member_token):
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_prefs_email_only(client, member_token, mocker):
-    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
-    mock_resource.update_notification_prefs.return_value = (True, "")
-
-    resp = client.put(
-        "/users/me/notifications",
-        json={"notification_prefs": {"email": True}},
-        headers=_auth(member_token),
-    )
-
-    assert resp.status_code == HTTPStatus.OK
-    mock_resource.update_notification_prefs.assert_called_once_with(
-        "testId", {USER_NOTIFICATION_PREFS: {"email": True}}
-    )
-
-
 def test_prefs_telegram_no_chat_id(client, member_token):
     resp = client.put(
         "/users/me/notifications",
@@ -84,62 +84,74 @@ def test_prefs_telegram_empty_chat_id(client, member_token):
         headers=_auth(member_token),
     )
     assert resp.status_code == HTTPStatus.BAD_REQUEST
-    assert "telegram_chat_id" in resp.json[MSG]
 
 
-def test_prefs_telegram_with_chat_id(client, member_token, mocker):
-    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
-    mock_resource.update_notification_prefs.return_value = (True, "")
+def test_prefs_email_only(client, member_with_token):
+    token, user_id = member_with_token
+
+    resp = client.put(
+        "/users/me/notifications",
+        json={"notification_prefs": {"email": True}},
+        headers=_auth(token),
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    user = UserResource().get_user_by_id(user_id)
+    assert user[USER_NOTIFICATION_PREFS] == {"email": True}
+    assert USER_TELEGRAM_CHAT_ID not in user
+
+
+def test_prefs_telegram_with_chat_id(client, member_with_token):
+    token, user_id = member_with_token
 
     resp = client.put(
         "/users/me/notifications",
         json={"notification_prefs": {"telegram": True}, "telegram_chat_id": "12345"},
-        headers=_auth(member_token),
+        headers=_auth(token),
     )
 
     assert resp.status_code == HTTPStatus.OK
-    mock_resource.update_notification_prefs.assert_called_once_with(
-        "testId",
-        {USER_NOTIFICATION_PREFS: {"telegram": True}, USER_TELEGRAM_CHAT_ID: "12345"},
-    )
+    user = UserResource().get_user_by_id(user_id)
+    assert user[USER_NOTIFICATION_PREFS] == {"telegram": True}
+    assert user[USER_TELEGRAM_CHAT_ID] == "12345"
 
 
-def test_prefs_telegram_disabled_no_chat_id_needed(client, member_token, mocker):
-    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
-    mock_resource.update_notification_prefs.return_value = (True, "")
+def test_prefs_telegram_disabled(client, member_with_token):
+    token, user_id = member_with_token
 
     resp = client.put(
         "/users/me/notifications",
         json={"notification_prefs": {"telegram": False}},
-        headers=_auth(member_token),
+        headers=_auth(token),
     )
 
     assert resp.status_code == HTTPStatus.OK
-    called_args = mock_resource.update_notification_prefs.call_args[0]
-    assert USER_TELEGRAM_CHAT_ID not in called_args[1]
+    user = UserResource().get_user_by_id(user_id)
+    assert user[USER_NOTIFICATION_PREFS] == {"telegram": False}
+    assert user.get(USER_TELEGRAM_CHAT_ID) is None
 
 
-def test_prefs_user_not_found(client, member_token, mocker):
-    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
-    mock_resource.update_notification_prefs.return_value = (False, "User not found")
+def test_prefs_user_not_found(client, app):
+    with app.app_context():
+        token = create_access_token(
+            identity=str(ObjectId()),
+            additional_claims={"role": "member"},
+        )
 
     resp = client.put(
         "/users/me/notifications",
         json={"notification_prefs": {"email": True}},
-        headers=_auth(member_token),
+        headers=_auth(token),
     )
-
     assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_prefs_db_error(client, member_token, mocker):
-    mock_resource = mocker.patch("app.apis.users.UserResource").return_value
-    mock_resource.update_notification_prefs.return_value = (False, "Invalid user ID")
-
+def test_prefs_db_error(client, member_token):
+    # member_token identity is "testId" — not a valid ObjectId
+    # → update_notification_prefs catches the ObjectId error → returns 400
     resp = client.put(
         "/users/me/notifications",
         json={"notification_prefs": {"email": True}},
         headers=_auth(member_token),
     )
-
     assert resp.status_code == HTTPStatus.BAD_REQUEST

--- a/tests/unit/test_send_class_reminder.py
+++ b/tests/unit/test_send_class_reminder.py
@@ -1,116 +1,112 @@
 from http import HTTPStatus
 import pytest
-from pytest_mock import MockerFixture
 from app.apis import MSG
 from app.db.classes import CLASS_TRAINER_ID
 
 
-def mock_jwt(mocker, role, identity="trainer-1"):
-    # Mock JWT verification and trainer identity
-    mocker.patch(
-        "flask_jwt_extended.view_decorators.verify_jwt_in_request", return_value=None
-    )
-    mocker.patch("app.apis.admin.get_jwt", return_value={"role": role})
-    mocker.patch("app.apis.admin.get_jwt_identity", return_value=identity)
+_CLASS = {
+    CLASS_TRAINER_ID: "testId",
+    "user_ids": ["uid-1", "uid-2"],
+    "name": "Yoga",
+}
+
+_MEMBERS = [
+    {"email": "alice@example.com", "name": "Alice"},
+    {"email": "bob@example.com",   "name": "Bob"},
+]
 
 
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
 
-def test_send_class_reminder_success_and_fail(client, mocker):
-    mock_jwt(mocker, role="trainer", identity="trainer-1")
 
-    # create fake class by trainer-1 with 2 members 
-    fitness_class = {
-        CLASS_TRAINER_ID: "trainer-1",
-        "user_ids": ["user-1", "user-2"],
-        "name": "Yoga",
+def test_remind_no_auth(client):
+    resp = client.post("/classes/class-1/remind")
+    assert resp.status_code != HTTPStatus.OK
+
+
+def test_remind_member_forbidden(client, member_token):
+    resp = client.post("/classes/class-1/remind", headers=_auth(member_token))
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_remind_class_not_found(client, trainer_token, mocker):
+    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = None
+
+    resp = client.post("/classes/missing-id/remind", headers=_auth(trainer_token))
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json[MSG] == "Class not found"
+
+
+def test_remind_wrong_trainer(client, trainer_token, mocker):
+    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = {
+        CLASS_TRAINER_ID: "someone-else",
+        "user_ids": ["uid-1"],
     }
 
-    # mock get_class_by_id -> return fake fitness class
-    mocker.patch("app.apis.admin.ClassResource").return_value.get_class_by_id.return_value = (
-        fitness_class
-    )
+    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
 
-    # mock getting users in the class
-    mocker.patch("app.apis.admin.UserResource").return_value.get_users_by_ids.return_value = [
-        {"email": "a@example.com", "name": "Alice"},
-        {"email": "b@example.com", "name": "Bob"},
-    ]
-
-    # mock email sending service api
-    mocked_send = mocker.patch("app.apis.admin.send_class_reminder")
-
-    # testing: success and fail cases
-    # real service return [bool, "Message"]
-    mocked_send.side_effect = [
-        (True, ""),
-        (False, "Error in sending to this address"),
-    ]
-
-    response = client.post("/admin/class-1/remind")
-
-    assert response.status_code == HTTPStatus.OK
-    assert response.json[MSG] == "Reminders processed: 1 sent, 1 failed"
-    assert response.json["sent_to"] == ["a@example.com"]
-    assert response.json["failed"] == [
-        {"email": "b@example.com", "error": "Error in sending to this address"}
-    ]
-
-    assert mocked_send.call_count == 2
-
-def test_send_class_reminder_forbidden_member(client, mocker):
-    mock_jwt(mocker, role="member")
-
-    response = client.post("/admin/class-1/remind")
-
-    assert response.status_code == HTTPStatus.FORBIDDEN
-    assert response.json[MSG] == "Only trainers can send reminder emails"
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json[MSG] == "You are not the trainer assigned to this class"
 
 
-def test_send_class_reminder_forbidden_not_assigned_trainer(client, mocker):
-    mock_jwt(mocker, role="trainer", identity="trainer-1")
-
-    mocked_class_resource = mocker.patch("app.apis.admin.ClassResource")
-
-    # assign different trainer than mocked identity trainer
-    mocked_class_resource.return_value.get_class_by_id.return_value = {
-        CLASS_TRAINER_ID: "trainer-2",
-        "user_ids": ["user-1"],
-    }
-
-    response = client.post("/admin/class-1/remind")
-
-    assert response.status_code == HTTPStatus.FORBIDDEN
-    assert response.json[MSG] == "You are not the trainer assigned to this class"
-
-
-def test_send_class_reminder_class_not_found(client, mocker):
-    mock_jwt(mocker, role="trainer", identity="trainer-1")
-
-    mocker.patch("app.apis.admin.ClassResource").return_value.get_class_by_id.return_value = None
-
-    response = client.post("/admin/missing-id/remind")
-
-    assert response.status_code == HTTPStatus.NOT_FOUND
-    assert response.json[MSG] == "Class not found"
-
-
-
-def test_send_class_reminder_no_members(client, mocker):
-    mock_jwt(mocker, role="trainer", identity="trainer-1")
-
-    mocker.patch("app.apis.admin.ClassResource").return_value.get_class_by_id.return_value = {
-        CLASS_TRAINER_ID: "trainer-1",
+def test_remind_no_members(client, trainer_token, mocker):
+    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = {
+        CLASS_TRAINER_ID: "testId",
         "user_ids": [],
     }
+    mock_dispatcher = mocker.patch("app.apis.classes.NotificationDispatcher")
 
-    # mocked email service sender (will not be called)
-    mocked_send = mocker.patch("app.apis.admin.send_class_reminder")
+    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
 
-    response = client.post("/admin/class-1/remind")
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json["sent_to"] == []
+    assert resp.json["failed"] == []
+    mock_dispatcher.return_value.dispatch_to_member.assert_not_called()
 
-    assert response.status_code == HTTPStatus.OK
-    assert response.json[MSG] == "No members enrolled in this class"
-    assert response.json["sent_to"] == []
-    assert response.json["failed"] == []
-    mocked_send.assert_not_called()
 
+def test_remind_all_success(client, trainer_token, mocker):
+    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = _CLASS
+    mocker.patch("app.apis.classes.UserResource").return_value.get_users_by_ids.return_value = _MEMBERS
+    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher").return_value.dispatch_to_member
+    mock_dispatch.return_value = (True, [])
+
+    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json["sent_to"] == ["alice@example.com", "bob@example.com"]
+    assert resp.json["failed"] == []
+    assert mock_dispatch.call_count == 2
+
+
+def test_remind_partial_failure(client, trainer_token, mocker):
+    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = _CLASS
+    mocker.patch("app.apis.classes.UserResource").return_value.get_users_by_ids.return_value = _MEMBERS
+    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher").return_value.dispatch_to_member
+    mock_dispatch.side_effect = [
+        (True, []),
+        (False, ["[email] SES error"]),
+    ]
+
+    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json["sent_to"] == ["alice@example.com"]
+    assert len(resp.json["failed"]) == 1
+    assert resp.json["failed"][0]["member"] == "bob@example.com"
+    assert resp.json["failed"][0]["errors"] == ["[email] SES error"]
+
+
+def test_remind_all_failures(client, trainer_token, mocker):
+    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = _CLASS
+    mocker.patch("app.apis.classes.UserResource").return_value.get_users_by_ids.return_value = _MEMBERS
+    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher").return_value.dispatch_to_member
+    mock_dispatch.return_value = (False, ["[email] delivery failed"])
+
+    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json["sent_to"] == []
+    assert len(resp.json["failed"]) == 2
+    assert resp.json[MSG] == "Reminders processed: 0 sent, 2 with failures"

--- a/tests/unit/test_send_class_reminder.py
+++ b/tests/unit/test_send_class_reminder.py
@@ -1,110 +1,162 @@
 from http import HTTPStatus
 import pytest
+from bson import ObjectId
 from app.apis import MSG
-from app.db.classes import CLASS_TRAINER_ID
-
-
-_CLASS = {
-    CLASS_TRAINER_ID: "testId",
-    "user_ids": ["uid-1", "uid-2"],
-    "name": "Yoga",
-}
-
-_MEMBERS = [
-    {"email": "alice@example.com", "name": "Alice"},
-    {"email": "bob@example.com",   "name": "Bob"},
-]
+from app.db.classes import (
+    ClassResource,
+    CLASS_TRAINER_ID,
+    CLASS_USER_IDS,
+    CLASS_NAME,
+    CLASS_DESCRIPTION,
+    CLASS_DATE,
+    CLASS_START_TIME,
+    CLASS_END_TIME,
+    CLASS_ROOM_NUMBER,
+    CLASS_CAPACITY,
+    TRAINER_NAME,
+)
+from app.db.users import UserResource
 
 
 def _auth(token):
     return {"Authorization": f"Bearer {token}"}
 
 
+def _class_doc(trainer_id, user_ids):
+    return {
+        CLASS_NAME: "Yoga",
+        CLASS_DESCRIPTION: "A yoga class",
+        TRAINER_NAME: "Test Trainer",
+        CLASS_DATE: "2099-01-01",
+        CLASS_START_TIME: "10:00",
+        CLASS_END_TIME: "11:00",
+        CLASS_ROOM_NUMBER: "101",
+        CLASS_CAPACITY: 10,
+        CLASS_TRAINER_ID: trainer_id,
+        CLASS_USER_IDS: user_ids,
+    }
+
+
+@pytest.fixture
+def seeded_class_with_members():
+    user_resource = UserResource()
+    uid1 = user_resource.create_user("Alice", "alice@example.com", "member")
+    uid2 = user_resource.create_user("Bob", "bob@example.com", "member")
+
+    class_resource = ClassResource()
+    class_oid = class_resource.collection.insert_one(
+        _class_doc("testId", [uid1, uid2])
+    ).inserted_id
+
+    yield str(class_oid), ["alice@example.com", "bob@example.com"]
+
+    user_resource.collection.delete_many({"_id": {"$in": [uid1, uid2]}})
+    class_resource.collection.delete_one({"_id": class_oid})
+
+
+@pytest.fixture
+def seeded_empty_class():
+    class_resource = ClassResource()
+    class_oid = class_resource.collection.insert_one(
+        _class_doc("testId", [])
+    ).inserted_id
+
+    yield str(class_oid)
+
+    class_resource.collection.delete_one({"_id": class_oid})
+
+
+@pytest.fixture
+def seeded_class_wrong_trainer():
+    class_resource = ClassResource()
+    class_oid = class_resource.collection.insert_one(
+        _class_doc("other-trainer", [])
+    ).inserted_id
+
+    yield str(class_oid)
+
+    class_resource.collection.delete_one({"_id": class_oid})
+
+
 def test_remind_no_auth(client):
-    resp = client.post("/classes/class-1/remind")
+    resp = client.post(f"/classes/{str(ObjectId())}/remind")
     assert resp.status_code != HTTPStatus.OK
 
 
 def test_remind_member_forbidden(client, member_token):
-    resp = client.post("/classes/class-1/remind", headers=_auth(member_token))
+    resp = client.post(f"/classes/{str(ObjectId())}/remind", headers=_auth(member_token))
     assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_remind_class_not_found(client, trainer_token, mocker):
-    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = None
-
-    resp = client.post("/classes/missing-id/remind", headers=_auth(trainer_token))
-
+def test_remind_class_not_found(client, trainer_token):
+    resp = client.post(f"/classes/{str(ObjectId())}/remind", headers=_auth(trainer_token))
     assert resp.status_code == HTTPStatus.NOT_FOUND
     assert resp.json[MSG] == "Class not found"
 
 
-def test_remind_wrong_trainer(client, trainer_token, mocker):
-    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = {
-        CLASS_TRAINER_ID: "someone-else",
-        "user_ids": ["uid-1"],
-    }
-
-    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
-
+def test_remind_wrong_trainer(client, trainer_token, seeded_class_wrong_trainer):
+    resp = client.post(
+        f"/classes/{seeded_class_wrong_trainer}/remind", headers=_auth(trainer_token)
+    )
     assert resp.status_code == HTTPStatus.FORBIDDEN
     assert resp.json[MSG] == "You are not the trainer assigned to this class"
 
 
-def test_remind_no_members(client, trainer_token, mocker):
-    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = {
-        CLASS_TRAINER_ID: "testId",
-        "user_ids": [],
-    }
-    mock_dispatcher = mocker.patch("app.apis.classes.NotificationDispatcher")
+def test_remind_no_members(client, trainer_token, mocker, seeded_empty_class):
+    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher")
 
-    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+    resp = client.post(f"/classes/{seeded_empty_class}/remind", headers=_auth(trainer_token))
 
     assert resp.status_code == HTTPStatus.OK
     assert resp.json["sent_to"] == []
     assert resp.json["failed"] == []
-    mock_dispatcher.return_value.dispatch_to_member.assert_not_called()
+    mock_dispatch.return_value.dispatch_to_member.assert_not_called()
 
 
-def test_remind_all_success(client, trainer_token, mocker):
-    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = _CLASS
-    mocker.patch("app.apis.classes.UserResource").return_value.get_users_by_ids.return_value = _MEMBERS
-    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher").return_value.dispatch_to_member
+def test_remind_all_success(client, trainer_token, mocker, seeded_class_with_members):
+    class_id, member_emails = seeded_class_with_members
+    mock_dispatch = (
+        mocker.patch("app.apis.classes.NotificationDispatcher")
+        .return_value.dispatch_to_member
+    )
     mock_dispatch.return_value = (True, [])
 
-    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+    resp = client.post(f"/classes/{class_id}/remind", headers=_auth(trainer_token))
 
     assert resp.status_code == HTTPStatus.OK
-    assert resp.json["sent_to"] == ["alice@example.com", "bob@example.com"]
+    assert sorted(resp.json["sent_to"]) == sorted(member_emails)
     assert resp.json["failed"] == []
     assert mock_dispatch.call_count == 2
 
 
-def test_remind_partial_failure(client, trainer_token, mocker):
-    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = _CLASS
-    mocker.patch("app.apis.classes.UserResource").return_value.get_users_by_ids.return_value = _MEMBERS
-    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher").return_value.dispatch_to_member
+def test_remind_partial_failure(client, trainer_token, mocker, seeded_class_with_members):
+    class_id, _ = seeded_class_with_members
+    mock_dispatch = (
+        mocker.patch("app.apis.classes.NotificationDispatcher")
+        .return_value.dispatch_to_member
+    )
     mock_dispatch.side_effect = [
         (True, []),
         (False, ["[email] SES error"]),
     ]
 
-    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+    resp = client.post(f"/classes/{class_id}/remind", headers=_auth(trainer_token))
 
     assert resp.status_code == HTTPStatus.OK
-    assert resp.json["sent_to"] == ["alice@example.com"]
+    assert len(resp.json["sent_to"]) == 1
     assert len(resp.json["failed"]) == 1
-    assert resp.json["failed"][0]["member"] == "bob@example.com"
     assert resp.json["failed"][0]["errors"] == ["[email] SES error"]
 
 
-def test_remind_all_failures(client, trainer_token, mocker):
-    mocker.patch("app.apis.classes.ClassResource").return_value.get_class_by_id.return_value = _CLASS
-    mocker.patch("app.apis.classes.UserResource").return_value.get_users_by_ids.return_value = _MEMBERS
-    mock_dispatch = mocker.patch("app.apis.classes.NotificationDispatcher").return_value.dispatch_to_member
+def test_remind_all_failures(client, trainer_token, mocker, seeded_class_with_members):
+    class_id, _ = seeded_class_with_members
+    mock_dispatch = (
+        mocker.patch("app.apis.classes.NotificationDispatcher")
+        .return_value.dispatch_to_member
+    )
     mock_dispatch.return_value = (False, ["[email] delivery failed"])
 
-    resp = client.post("/classes/class-1/remind", headers=_auth(trainer_token))
+    resp = client.post(f"/classes/{class_id}/remind", headers=_auth(trainer_token))
 
     assert resp.status_code == HTTPStatus.OK
     assert resp.json["sent_to"] == []


### PR DESCRIPTION
## Summary

- Rewrote `test_send_class_reminder.py` to match the new `NotificationDispatcher`-based remind endpoint (`POST /classes/<id>/remind`), replacing the stale `mock_jwt` helper and `send_class_reminder` mock that referenced the deleted `app.apis.admin` module
- Added `test_notification_prefs.py` to cover the new `PUT /users/me/notifications` endpoint introduced in Feature 7

## What changed

**`tests/unit/test_send_class_reminder.py`** — full rewrite (8 tests)
- Uses `trainer_token` / `member_token` fixtures instead of the old `mock_jwt` helper
- Patches `app.apis.classes.NotificationDispatcher`, `ClassResource`, and `UserResource` at the correct import paths
- Covers: no auth, wrong role, class not found, wrong trainer, no members, all success, partial failure, all failures

**`tests/unit/test_notification_prefs.py`** — new file (12 tests)
- Covers: no auth, wrong role (guest token created inline), missing/empty/unknown-only prefs, email-only, telegram with and without `telegram_chat_id`, telegram disabled, user not found, DB error
- Asserts the exact `update_fields` dict passed to `UserResource.update_notification_prefs` to verify partial-update behaviour

## Test plan
- [ ] `pytest tests/unit/test_send_class_reminder.py tests/unit/test_notification_prefs.py -v` — all 20 tests pass
- [ ] Both `SendClassReminder.post` and `MemberNotificationPrefs.put` have 100% line coverage