### PR TITLE
Added tests for more coverage, added to test_auth, test_users and cre…

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -65,6 +65,12 @@ def test_register_duplicate_email(client):
     assert second.status_code == HTTPStatus.CONFLICT
     assert second.json[MSG] == "Email already registered"
 
+def test_register_password_no_uppercase(client):
+    resp = client.post("/auth/register", json={
+        "name": "Test", "email": "test@test.com",
+        "password": "validpass1!", "role": "member"
+    })
+    assert resp.status_code == 400
 
 # LOGIN TESTS
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -113,8 +113,7 @@ def test_telegram_generic_error():
 def test_dispatcher_email_success():
     """A member with email enabled gets a reminder and returns no errors."""
     member = {**_MEMBER, "notification_prefs": {"email": True, "telegram": False}}
-    with patch("app.services.notifications.dispatcher.EmailNotificationService") as mock_cls:
-        mock_cls.return_value.send.return_value = (True, "")
+    with patch.object(EmailNotificationService, "send", return_value=(True, "")):
         ok, errors = NotificationDispatcher().dispatch_to_member(member, _CLASS)
     assert ok is True
     assert errors == []
@@ -122,8 +121,7 @@ def test_dispatcher_email_success():
 
 def test_dispatcher_no_prefs_defaults_to_email():
     """A member with no notification_prefs falls back to the email default."""
-    with patch("app.services.notifications.dispatcher.EmailNotificationService") as mock_cls:
-        mock_cls.return_value.send.return_value = (True, "")
+    with patch.object(EmailNotificationService, "send", return_value=(True, "")):
         ok, errors = NotificationDispatcher().dispatch_to_member(_MEMBER, _CLASS)
     assert ok is True
 
@@ -131,8 +129,7 @@ def test_dispatcher_no_prefs_defaults_to_email():
 def test_dispatcher_records_failure():
     """A failed channel is recorded in the errors list."""
     member = {**_MEMBER, "notification_prefs": {"email": True}}
-    with patch("app.services.notifications.dispatcher.EmailNotificationService") as mock_cls:
-        mock_cls.return_value.send.return_value = (False, "SES down")
+    with patch.object(EmailNotificationService, "send", return_value=(False, "SES down")):
         ok, errors = NotificationDispatcher().dispatch_to_member(member, _CLASS)
     assert ok is False
     assert "[email] SES down" in errors

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for notification service classes.
+
+Services covered:
+  NotificationService._build_message        — builds subject and body from class info
+  EmailNotificationService.send             — sends reminder via AWS SES
+  TelegramNotificationService.send          — sends reminder via Telegram Bot API
+  NotificationDispatcher.dispatch_to_member — routes reminder to enabled channels
+"""
+
+import urllib.error
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import ClientError
+
+from app.services.notifications.email_service import EmailNotificationService
+from app.services.notifications.telegram_service import TelegramNotificationService
+from app.services.notifications.dispatcher import NotificationDispatcher
+
+
+_CLASS = {
+    "name": "Yoga",
+    "description": "Relaxing session",
+    "trainer_name": "Sam",
+    "date": "2030-01-01",
+    "start_time": "10:00",
+    "end_time": "11:00",
+    "room_number": "101",
+}
+_MEMBER    = {"name": "Alice", "email": "alice@example.com"}
+_MEMBER_TG = {**_MEMBER, "telegram_chat_id": "123456"}
+
+
+# ─── Tests: _build_message ────────────────────────────────────────────────────
+
+
+def test_build_message_subject():
+    """Subject contains the class name."""
+    msg = EmailNotificationService()._build_message("Alice", _CLASS)
+    assert "Yoga" in msg["subject"]
+
+
+def test_build_message_body():
+    """Body contains the member name and class start time."""
+    msg = EmailNotificationService()._build_message("Alice", _CLASS)
+    assert "Alice" in msg["body"]
+    assert "10:00" in msg["body"]
+
+
+# ─── Tests: EmailNotificationService ─────────────────────────────────────────
+
+
+def test_email_send_success():
+    """A successful SES call returns (True, '')."""
+    with patch("app.services.notifications.email_service.boto3.client") as mock_boto:
+        mock_boto.return_value.send_email.return_value = {}
+        ok, err = EmailNotificationService().send(_MEMBER, _CLASS)
+    assert ok is True
+    assert err == ""
+
+
+def test_email_send_failure():
+    """A ClientError from SES returns (False, error message)."""
+    error = {"Error": {"Code": "MessageRejected", "Message": "Address blacklisted"}}
+    with patch("app.services.notifications.email_service.boto3.client") as mock_boto:
+        mock_boto.return_value.send_email.side_effect = ClientError(error, "SendEmail")
+        ok, err = EmailNotificationService().send(_MEMBER, _CLASS)
+    assert ok is False
+    assert "blacklisted" in err
+
+
+# ─── Tests: TelegramNotificationService ──────────────────────────────────────
+
+
+def test_telegram_missing_chat_id():
+    """A member without a telegram_chat_id returns (False, error)."""
+    ok, err = TelegramNotificationService().send(_MEMBER, _CLASS)
+    assert ok is False
+    assert "telegram_chat_id" in err
+
+
+def test_telegram_send_success():
+    """A successful Telegram request returns (True, '')."""
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    with patch("app.services.notifications.telegram_service.urllib.request.urlopen", return_value=mock_resp):
+        ok, err = TelegramNotificationService().send(_MEMBER_TG, _CLASS)
+    assert ok is True
+    assert err == ""
+
+
+def test_telegram_http_error():
+    """An HTTPError from Telegram returns (False, error with status code)."""
+    with patch("app.services.notifications.telegram_service.urllib.request.urlopen") as mock_open:
+        mock_open.side_effect = urllib.error.HTTPError(None, 400, "Bad Request", {}, None)
+        ok, err = TelegramNotificationService().send(_MEMBER_TG, _CLASS)
+    assert ok is False
+    assert "400" in err
+
+
+def test_telegram_generic_error():
+    """Any unexpected exception returns (False, error message)."""
+    with patch("app.services.notifications.telegram_service.urllib.request.urlopen") as mock_open:
+        mock_open.side_effect = Exception("timeout")
+        ok, err = TelegramNotificationService().send(_MEMBER_TG, _CLASS)
+    assert ok is False
+    assert "timeout" in err
+
+
+# ─── Tests: NotificationDispatcher ───────────────────────────────────────────
+
+
+def test_dispatcher_email_success():
+    """A member with email enabled gets a reminder and returns no errors."""
+    member = {**_MEMBER, "notification_prefs": {"email": True, "telegram": False}}
+    with patch("app.services.notifications.dispatcher.EmailNotificationService") as mock_cls:
+        mock_cls.return_value.send.return_value = (True, "")
+        ok, errors = NotificationDispatcher().dispatch_to_member(member, _CLASS)
+    assert ok is True
+    assert errors == []
+
+
+def test_dispatcher_no_prefs_defaults_to_email():
+    """A member with no notification_prefs falls back to the email default."""
+    with patch("app.services.notifications.dispatcher.EmailNotificationService") as mock_cls:
+        mock_cls.return_value.send.return_value = (True, "")
+        ok, errors = NotificationDispatcher().dispatch_to_member(_MEMBER, _CLASS)
+    assert ok is True
+
+
+def test_dispatcher_records_failure():
+    """A failed channel is recorded in the errors list."""
+    member = {**_MEMBER, "notification_prefs": {"email": True}}
+    with patch("app.services.notifications.dispatcher.EmailNotificationService") as mock_cls:
+        mock_cls.return_value.send.return_value = (False, "SES down")
+        ok, errors = NotificationDispatcher().dispatch_to_member(member, _CLASS)
+    assert ok is False
+    assert "[email] SES down" in errors

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -141,6 +141,20 @@ def test_get_enrolled_classes_invalid_id_format(client,member_token):
     assert resp.status_code == HTTPStatus.BAD_REQUEST
     assert resp.get_json()[MSG] == "Invalid user ID format"
 
+def test_get_enrolled_classes_returns_list(client, member_auth, seeded_class):
+    """Enrolled classes return a list after booking."""
+    headers = {"Authorization": f"Bearer {member_auth}"}
+    client.post(f"/users/me/book{seeded_class}", headers=headers)
+    resp = client.get("/users/me/book", headers=headers)
+    assert isinstance(resp.get_json(),list)
+
+def test_get_enrolled_classes_empty_identity(client, app):
+    """JWT with empty identity returns 401."""
+    with app.app_context():
+        token = create_access_token(identity="", additional_claims={"role": "member"})
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get("/users/me/book", headers=headers)
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 # ─── Tests: Update notification preferences  (PUT /users/me/notifications) ────
 
@@ -222,7 +236,7 @@ def test_update_notifications_telegram_whitespace_chat_id(client, member_auth):
 
 def test_update_notifications_persisted_in_db(client, member_auth, app):
     """After a successful PUT, preferences are actually saved in the DB."""
-    
+
     headers = {"Authorization": f"Bearer {member_auth}"}
     client.put("/users/me/notifications", json={
         "notification_prefs": {"email": True},


### PR DESCRIPTION
- Added tests for more coverage, added to test_auth, test_users and crated new test file test_notifications. 
- Add tests for EmailNotificationService.send: success, ClientError failure
- Add tests for TelegramNotificationService.send: missing chat_id, success, HTTP error, generic error
- Add tests for NotificationDispatcher.dispatch_to_member: email success, no prefs defaults to email, failure recorded in errors list