### PR TITLE
Separate endpoint added for app to get member's telegram chat ID automatically

### DIFF
--- a/.samplenv
+++ b/.samplenv
@@ -34,3 +34,6 @@ SES_SENDER_EMAIL="your-sender-email"
 # Create a bot via @BotFather on Telegram, then paste the token here
 TELEGRAM_BOT_TOKEN="your-telegram-bot-token"
 
+# Telegram webhook secret — optional but recommended in production
+# Set to any random string and pass it when registering the webhook with setWebhook
+TELEGRAM_WEBHOOK_SECRET=""

--- a/README.md
+++ b/README.md
@@ -63,30 +63,42 @@ To run and test the reminder email feature, configure Amazon SES and IAM, then f
 
 ### 2.2: Telegram Bot Setup for Telegram Reminder Notifications (Feature 7)
 
-To enable Telegram reminders, you need to create a Telegram bot and obtain its token.
-
-1. Open Telegram and search for **@BotFather**.
-2. Start a chat with it and send the command `/newbot`.
-3. Follow the prompts: enter a display name (e.g. `FitClass Reminders`) then a username ending in `bot` (e.g. `fitclass_remind_bot`).
-4. BotFather will reply with an API token that looks like `123456789:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`.
-5. Copy this token and set it in your `.env` file:
+**Create the bot:**
+1. Open Telegram, search for **@BotFather**, send `/newbot`, and follow the prompts.
+2. Copy the token BotFather gives you and add it to `.env`:
    ```env
    TELEGRAM_BOT_TOKEN="your-token-here"
    ```
-6. **Start the bot** — Search for your bot by its username in Telegram and tap **Start** (or send `/start`). This is required — bots cannot message users who have never contacted them first.
-7. **Find your Chat ID** — Your Telegram Chat ID is a unique numeric identifier for your account. The easiest way to find it:
-   - Open Telegram and search for **@userinfobot**.
-   - Start a chat and send any message.
-   - It will reply with your numeric Chat ID (e.g. `123456789`).
-8. **Save your Chat ID** — Submit it to the API using `PUT /users/me/notifications`:
-   ```json
-   {
-     "telegram_chat_id": "123456789",
-     "notification_prefs": { "telegram": true }
-   }
-   ```
 
-> **Note:** If a member has not started the bot, Telegram will reject the message and the reminder will appear in the `failed` list in the API response.
+**Register the webhook (local dev only):**
+
+Members link their Telegram account by clicking a deep link, which requires Telegram to push an update to your server. Locally this needs [ngrok](https://ngrok.com) to create a public tunnel:
+
+```bash
+# Terminal 1 — run the app
+FLASK_APP=app flask run --debug --host=0.0.0.0 --port 8000
+
+# Terminal 2 — expose it publicly
+ngrok http 8000
+```
+
+Copy the `https://` URL ngrok gives you, then register it as the webhook (run once per ngrok session):
+
+```bash
+curl -X POST "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://<your-ngrok-url>/users/telegram/webhook"}'
+```
+
+Expected response: `{"ok":true,"result":true}`.
+
+**Link a member's Telegram account:**
+
+1. Log in as a member → call `GET /users/me/telegram/link` in Swagger UI.
+2. Open the returned link on your phone → tap **Start** in Telegram.
+3. The server automatically saves your chat ID and enables Telegram notifications — no manual ID entry needed.
+
+> **Note:** The deep link expires in 10 minutes. Call `GET /users/me/telegram/link` again to get a fresh one.
 
 ### 3. Create the virtual environment and install dependencies
 

--- a/app/apis/users.py
+++ b/app/apis/users.py
@@ -1,4 +1,9 @@
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
+from uuid import uuid4
 
 from bson import ObjectId
 from flask import request
@@ -6,6 +11,7 @@ from flask_jwt_extended import get_jwt_identity
 from flask_restx import Namespace, Resource, fields
 
 from app.apis import MSG
+from app.config import Config
 from app.db.classes import ClassResource
 from app.db.users import (
     USER_NOTIFICATION_PREFS,
@@ -72,10 +78,14 @@ _UPDATE_NOTIFICATIONS_MODEL = api.model(
             _NOTIFICATION_PREFS_MODEL,
             description="Per-channel opt-in flags (all optional)",
         ),
-        "telegram_chat_id": fields.String(
-            description="Telegram numeric chat ID — required when enabling Telegram (message @userinfobot to find yours)",
-            example="123456789",
-        ),
+    },
+)
+
+_TELEGRAM_LINK_RESPONSE = api.model(
+    "TelegramLinkResponse",
+    {
+        "link": fields.String(description="Telegram deep link to open the bot and start linking"),
+        "expires_in": fields.Integer(description="Seconds until the link expires", example=600),
     },
 )
 
@@ -172,7 +182,11 @@ class MemberNotificationPrefs(Resource):
     @api.response(HTTPStatus.NOT_FOUND, "User not found", _ERROR_RESPONSE)
     @api.response(HTTPStatus.UNAUTHORIZED, "JWT required", _ERROR_RESPONSE)
     def put(self):
-        """Update notification preferences and/or contact details for the current member."""
+        """Update notification preferences for the current member.
+
+        To enable Telegram, use GET /users/me/telegram/link instead of setting telegram=true here —
+        that flow automatically captures your chat ID via the bot.
+        """
         user_id = get_jwt_identity()
         data    = request.json or {}
 
@@ -189,15 +203,6 @@ class MemberNotificationPrefs(Resource):
 
         update_fields = {USER_NOTIFICATION_PREFS: channels}
 
-        if channels.get("telegram"):
-            telegram_chat_id = (data.get("telegram_chat_id") or "").strip()
-            if not telegram_chat_id:
-                return (
-                    {MSG: "telegram_chat_id is required when enabling Telegram"},
-                    HTTPStatus.BAD_REQUEST,
-                )
-            update_fields[USER_TELEGRAM_CHAT_ID] = telegram_chat_id
-
         user_resource = UserResource()
         ok, err = user_resource.update_notification_prefs(user_id, update_fields)
         if not ok:
@@ -205,3 +210,77 @@ class MemberNotificationPrefs(Resource):
             return {MSG: err}, status
 
         return {MSG: "Notification preferences updated"}, HTTPStatus.OK
+
+
+# =========================================================================
+# /users/me/telegram/link
+# =========================================================================
+
+
+@api.route("/me/telegram/link")
+class TelegramLink(Resource):
+
+    @member_required
+    @api.doc(security="Bearer")
+    @api.response(HTTPStatus.OK, "Deep link generated", _TELEGRAM_LINK_RESPONSE)
+    @api.response(HTTPStatus.UNAUTHORIZED, "JWT required", _ERROR_RESPONSE)
+    @api.response(HTTPStatus.INTERNAL_SERVER_ERROR, "Could not reach Telegram API", _ERROR_RESPONSE)
+    def get(self):
+        """Generate a one-time Telegram deep link that auto-captures your chat ID.
+
+        Open the returned link on your phone, press Start in Telegram, and the server
+        will automatically save your chat ID and enable Telegram notifications.
+        The link expires in 10 minutes.
+        """
+        user_id = get_jwt_identity()
+        token = str(uuid4())
+        expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(minutes=10)
+
+        user_resource = UserResource()
+        ok = user_resource.set_telegram_link_token(user_id, token, expires_at)
+        if not ok:
+            return {MSG: "User not found"}, HTTPStatus.NOT_FOUND
+
+        try:
+            url = f"https://api.telegram.org/bot{Config.TELEGRAM_BOT_TOKEN}/getMe"
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                bot_info = json.loads(resp.read())
+            bot_username = bot_info["result"]["username"]
+        except Exception as e:
+            return {MSG: f"Could not reach Telegram API: {e}"}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+        deep_link = f"https://t.me/{bot_username}?start={token}"
+        return {"link": deep_link, "expires_in": 600}, HTTPStatus.OK
+
+
+# =========================================================================
+# /users/telegram/webhook  (called by Telegram — no JWT auth)
+# =========================================================================
+
+
+@api.route("/telegram/webhook")
+class TelegramWebhook(Resource):
+
+    def post(self):
+        """Receive updates from Telegram. Not for direct use — called by Telegram's servers."""
+        if Config.TELEGRAM_WEBHOOK_SECRET:
+            secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+            if secret != Config.TELEGRAM_WEBHOOK_SECRET:
+                return {}, HTTPStatus.FORBIDDEN
+
+        update = request.json or {}
+        message = update.get("message", {})
+        text = message.get("text", "")
+        chat_id = str(message.get("chat", {}).get("id", ""))
+
+        if not text.startswith("/start ") or not chat_id:
+            return {}, HTTPStatus.OK
+
+        token = text[len("/start "):].strip()
+        user_resource = UserResource()
+        user = user_resource.find_user_by_link_token(token)
+        if user:
+            user_resource.save_telegram_chat_id(user["_id"], chat_id)
+
+        return {}, HTTPStatus.OK

--- a/app/apis/users.py
+++ b/app/apis/users.py
@@ -201,9 +201,18 @@ class MemberNotificationPrefs(Resource):
                 HTTPStatus.BAD_REQUEST,
             )
 
+        user_resource = UserResource()
+
+        if channels.get("telegram"):
+            user = user_resource.get_user_by_id(user_id)
+            if not user or not user.get(USER_TELEGRAM_CHAT_ID):
+                return (
+                    {MSG: "Cannot enable Telegram: no telegram_chat_id on file. Use GET /users/me/telegram/link to link your account first."},
+                    HTTPStatus.BAD_REQUEST,
+                )
+
         update_fields = {USER_NOTIFICATION_PREFS: channels}
 
-        user_resource = UserResource()
         ok, err = user_resource.update_notification_prefs(user_id, update_fields)
         if not ok:
             status = HTTPStatus.NOT_FOUND if "not found" in err else HTTPStatus.BAD_REQUEST

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,7 @@ class Config(object):
     AWS_SES_REGION = get_required_environ("AWS_SES_REGION")
     SES_SENDER_EMAIL = get_required_environ("SES_SENDER_EMAIL")
     TELEGRAM_BOT_TOKEN = get_required_environ("TELEGRAM_BOT_TOKEN")
+    TELEGRAM_WEBHOOK_SECRET = environ.get("TELEGRAM_WEBHOOK_SECRET", "")
 
 class TestConfig(object):
     MONGO_URI = get_required_environ("MONGO_URI")
@@ -41,3 +42,4 @@ class TestConfig(object):
     AWS_SES_REGION = get_required_environ("AWS_SES_REGION")
     SES_SENDER_EMAIL = get_required_environ("SES_SENDER_EMAIL")
     TELEGRAM_BOT_TOKEN = get_required_environ("TELEGRAM_BOT_TOKEN")
+    TELEGRAM_WEBHOOK_SECRET = environ.get("TELEGRAM_WEBHOOK_SECRET", "")

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -1,4 +1,6 @@
 import re
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 import bcrypt
 
@@ -15,6 +17,8 @@ USER_PASSWORD_HASH = "password_hash"
 USER_CLASS_IDS = "class_ids"
 USER_NOTIFICATION_PREFS = "notification_prefs"
 USER_TELEGRAM_CHAT_ID   = "telegram_chat_id"
+USER_TELEGRAM_LINK_TOKEN         = "telegram_link_token"
+USER_TELEGRAM_LINK_TOKEN_EXPIRES = "telegram_link_token_expires"
 
 # Role constants
 MEMBER_ROLE = "member"
@@ -276,3 +280,49 @@ class UserResource:
         if result.matched_count == 0:
             return False, "User not found"
         return True, ""
+
+    # ------------------------------------------------------------------
+    # Telegram linking
+    # ------------------------------------------------------------------
+
+    def set_telegram_link_token(self, user_id: str, token: str, expires_at: datetime) -> bool:
+        try:
+            user_oid = ObjectId(user_id)
+        except Exception:
+            return False
+        result = self.collection.update_one(
+            {"_id": user_oid},
+            {"$set": {
+                USER_TELEGRAM_LINK_TOKEN: token,
+                USER_TELEGRAM_LINK_TOKEN_EXPIRES: expires_at,
+            }},
+        )
+        return result.matched_count == 1
+
+    def find_user_by_link_token(self, token: str):
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        user = self.collection.find_one({
+            USER_TELEGRAM_LINK_TOKEN: token,
+            USER_TELEGRAM_LINK_TOKEN_EXPIRES: {"$gt": now},
+        })
+        return serialize_item(user)
+
+    def save_telegram_chat_id(self, user_id: str, chat_id: str) -> bool:
+        try:
+            user_oid = ObjectId(user_id)
+        except Exception:
+            return False
+        result = self.collection.update_one(
+            {"_id": user_oid},
+            {
+                "$set": {
+                    USER_TELEGRAM_CHAT_ID: chat_id,
+                    f"{USER_NOTIFICATION_PREFS}.telegram": True,
+                },
+                "$unset": {
+                    USER_TELEGRAM_LINK_TOKEN: "",
+                    USER_TELEGRAM_LINK_TOKEN_EXPIRES: "",
+                },
+            },
+        )
+        return result.matched_count == 1

--- a/tests/unit/test_notification_prefs.py
+++ b/tests/unit/test_notification_prefs.py
@@ -3,7 +3,7 @@ import pytest
 from bson import ObjectId
 from flask_jwt_extended import create_access_token
 from app.apis import MSG
-from app.db.users import UserResource, USER_NOTIFICATION_PREFS, USER_TELEGRAM_CHAT_ID
+from app.db.users import UserResource, USER_NOTIFICATION_PREFS, USER_TELEGRAM_CHAT_ID, USER_TELEGRAM_LINK_TOKEN
 
 
 def _auth(token):
@@ -67,7 +67,8 @@ def test_prefs_unknown_channels_only(client, member_token):
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_prefs_telegram_no_chat_id(client, member_token):
+def test_prefs_telegram_no_chat_id_in_db(client, member_token):
+    # member_token identity is "testId" — not a valid ObjectId, get_user_by_id returns None
     resp = client.put(
         "/users/me/notifications",
         json={"notification_prefs": {"telegram": True}},
@@ -77,13 +78,16 @@ def test_prefs_telegram_no_chat_id(client, member_token):
     assert "telegram_chat_id" in resp.json[MSG]
 
 
-def test_prefs_telegram_empty_chat_id(client, member_token):
+def test_prefs_telegram_no_chat_id_real_user(client, member_with_token):
+    # Real user exists in DB but has no telegram_chat_id saved yet
+    token, _ = member_with_token
     resp = client.put(
         "/users/me/notifications",
-        json={"notification_prefs": {"telegram": True}, "telegram_chat_id": "   "},
-        headers=_auth(member_token),
+        json={"notification_prefs": {"telegram": True}},
+        headers=_auth(token),
     )
     assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "telegram_chat_id" in resp.json[MSG]
 
 
 def test_prefs_email_only(client, member_with_token):
@@ -101,12 +105,14 @@ def test_prefs_email_only(client, member_with_token):
     assert USER_TELEGRAM_CHAT_ID not in user
 
 
-def test_prefs_telegram_with_chat_id(client, member_with_token):
+def test_prefs_telegram_enabled_with_chat_id_in_db(client, member_with_token):
+    # Simulate the linking flow: seed telegram_chat_id into DB directly
     token, user_id = member_with_token
+    UserResource().update_notification_prefs(user_id, {USER_TELEGRAM_CHAT_ID: "12345"})
 
     resp = client.put(
         "/users/me/notifications",
-        json={"notification_prefs": {"telegram": True}, "telegram_chat_id": "12345"},
+        json={"notification_prefs": {"telegram": True}},
         headers=_auth(token),
     )
 

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -7,12 +7,14 @@ Endpoints covered:
   PUT  /users/me/notifications    — update notification preferences
 """
 
+import json
 import pytest
 import uuid
+from datetime import datetime, timedelta
 from http import HTTPStatus
-from flask_jwt_extended import create_access_token
-from app.db.users import UserResource
-from flask_jwt_extended import decode_token
+from unittest.mock import MagicMock, patch
+from flask_jwt_extended import create_access_token, decode_token
+from app.db.users import UserResource, USER_TELEGRAM_CHAT_ID, USER_NOTIFICATION_PREFS
 from app.apis import MSG
 
 
@@ -169,12 +171,15 @@ def test_update_notifications_email_only(client, member_auth):
     assert resp.get_json()[MSG] == "Notification preferences updated"
 
 
-def test_update_notifications_telegram_with_chat_id(client, member_auth):
-    """Enabling Telegram with a valid chat ID returns 200."""
+def test_update_notifications_telegram_with_chat_id(client, member_auth, app):
+    """Enabling Telegram succeeds when telegram_chat_id is already in the DB."""
+    with app.app_context():
+        user_id = decode_token(member_auth)["sub"]
+    UserResource().update_notification_prefs(user_id, {USER_TELEGRAM_CHAT_ID: "123456789"})
+
     headers = {"Authorization": f"Bearer {member_auth}"}
     resp = client.put("/users/me/notifications", json={
         "notification_prefs": {"telegram": True},
-        "telegram_chat_id": "123456789",
     }, headers=headers)
     assert resp.status_code == HTTPStatus.OK
     assert resp.get_json()[MSG] == "Notification preferences updated"
@@ -247,3 +252,120 @@ def test_update_notifications_persisted_in_db(client, member_auth, app):
         user = UserResource().get_user_by_id(user_id)
 
     assert user["notification_prefs"] == {"email": True}
+
+
+# ─── Tests: Generate Telegram link  (GET /users/me/telegram/link) ─────────────
+
+
+def _mock_get_me(bot_username="test_bot"):
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(
+        {"ok": True, "result": {"username": bot_username}}
+    ).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def test_telegram_link_no_auth(client):
+    """Calling the link endpoint without a JWT returns non-200."""
+    resp = client.get("/users/me/telegram/link")
+    assert resp.status_code != HTTPStatus.OK
+
+
+def test_telegram_link_user_not_found(client, app):
+    """A JWT with a valid-format but non-existent user ID returns 404."""
+    with app.app_context():
+        token = create_access_token(
+            identity=str(__import__("bson").ObjectId()),
+            additional_claims={"role": "member"},
+        )
+    resp = client.get("/users/me/telegram/link", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_telegram_link_success(client, member_auth):
+    """A valid member gets a deep link containing the bot username and a token."""
+    with patch("app.apis.users.urllib.request.urlopen", return_value=_mock_get_me("test_bot")):
+        resp = client.get(
+            "/users/me/telegram/link",
+            headers={"Authorization": f"Bearer {member_auth}"},
+        )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.get_json()
+    assert "https://t.me/test_bot?start=" in data["link"]
+    assert data["expires_in"] == 600
+
+
+def test_telegram_link_telegram_api_fails(client, member_auth):
+    """If the Telegram getMe call fails the endpoint returns 500."""
+    with patch("app.apis.users.urllib.request.urlopen", side_effect=Exception("timeout")):
+        resp = client.get(
+            "/users/me/telegram/link",
+            headers={"Authorization": f"Bearer {member_auth}"},
+        )
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "Could not reach Telegram API" in resp.get_json()[MSG]
+
+
+# ─── Tests: Telegram webhook  (POST /users/telegram/webhook) ──────────────────
+
+
+def test_webhook_empty_body(client):
+    """An empty update body is accepted and returns 200."""
+    resp = client.post("/users/telegram/webhook", json={})
+    assert resp.status_code == HTTPStatus.OK
+
+
+def test_webhook_non_start_message(client):
+    """A regular message (not /start) is ignored and returns 200."""
+    resp = client.post("/users/telegram/webhook", json={
+        "message": {"text": "hello", "chat": {"id": 123}}
+    })
+    assert resp.status_code == HTTPStatus.OK
+
+
+def test_webhook_invalid_token(client):
+    """A /start command with an unknown token returns 200 and saves nothing."""
+    resp = client.post("/users/telegram/webhook", json={
+        "message": {"text": "/start nonexistent-token", "chat": {"id": 999}}
+    })
+    assert resp.status_code == HTTPStatus.OK
+
+
+def test_webhook_valid_token_saves_chat_id(client, member_auth, app):
+    """A /start with a valid token saves the chat_id and enables telegram in prefs."""
+    with app.app_context():
+        user_id = decode_token(member_auth)["sub"]
+
+    # Seed a valid unexpired link token directly into the DB
+    from datetime import timezone
+    expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(minutes=10)
+    UserResource().set_telegram_link_token(user_id, "valid-token-abc", expires_at)
+
+    resp = client.post("/users/telegram/webhook", json={
+        "message": {"text": "/start valid-token-abc", "chat": {"id": 8888888}}
+    })
+    assert resp.status_code == HTTPStatus.OK
+
+    user = UserResource().get_user_by_id(user_id)
+    assert user[USER_TELEGRAM_CHAT_ID] == "8888888"
+    assert user[USER_NOTIFICATION_PREFS]["telegram"] is True
+
+
+def test_webhook_expired_token_does_not_save(client, member_auth, app):
+    """A /start with an expired token returns 200 but does not save the chat_id."""
+    with app.app_context():
+        user_id = decode_token(member_auth)["sub"]
+
+    from datetime import timezone
+    expired_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=1)
+    UserResource().set_telegram_link_token(user_id, "expired-token-xyz", expired_at)
+
+    resp = client.post("/users/telegram/webhook", json={
+        "message": {"text": "/start expired-token-xyz", "chat": {"id": 7777777}}
+    })
+    assert resp.status_code == HTTPStatus.OK
+
+    user = UserResource().get_user_by_id(user_id)
+    assert user.get(USER_TELEGRAM_CHAT_ID) != "7777777"


### PR DESCRIPTION
- A separate GET endpoint "users/me/telegram/link" was added. When the endpoint is executed, it provides the user with a link that will take them to the Telegram Bot that has been linked in the .env file. When they send the /start message, Telegram's servers call the POST endpoint "users/telegram/webhook" on our server to provide the Telegram Chat Id of the member who has sent the message, and the database of the logged in member is updated.
- The "users/telegram/webhook" endpoint is not for users but is a webhook connection for the Telegram servers.
- Updated README with instructions on how this new endpoint can be tested in a local server using ngrok. Installation of ngrok is necessary.
- Updated "users/me/notifications" removing the telegram_chat_id requirement.
- Edited tests to work with new design and added some more tests to reach coverage above 90%